### PR TITLE
Fix pythia6.428-1.0 NC noRad ep CSV file path patterns to include run number index

### DIFF
--- a/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1000to10000.csv
+++ b/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1000to10000.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1000to10000/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1000to10000_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1000to10000/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1000to10000_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_100to1000.csv
+++ b/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_100to1000.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_100to1000/pythia6.428-1.0_NC_noRad_ep_10x130_q2_100to1000_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_100to1000/pythia6.428-1.0_NC_noRad_ep_10x130_q2_100to1000_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_10to100.csv
+++ b/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_10to100.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_10to100/pythia6.428-1.0_NC_noRad_ep_10x130_q2_10to100_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_10to100/pythia6.428-1.0_NC_noRad_ep_10x130_q2_10to100_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10.csv
+++ b/DIS/ep/NC/10x130/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1000to10000.csv
+++ b/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1000to10000.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_1000to10000/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1000to10000_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_1000to10000/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1000to10000_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_100to1000.csv
+++ b/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_100to1000.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_100to1000/pythia6.428-1.0_NC_noRad_ep_10x250_q2_100to1000_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_100to1000/pythia6.428-1.0_NC_noRad_ep_10x250_q2_100to1000_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_10to100.csv
+++ b/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_10to100.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_10to100/pythia6.428-1.0_NC_noRad_ep_10x250_q2_10to100_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_10to100/pythia6.428-1.0_NC_noRad_ep_10x250_q2_10to100_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1to10.csv
+++ b/DIS/ep/NC/10x250/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1to10.csv
@@ -1,1 +1,1 @@
-DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1to10_ab,hepmc3.tree.root,0,0
+DIS/pythia6.428-1.0/NC/noRad/ep/10x250/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x250_q2_1to10_ab_run[0-9]+$,hepmc3.tree.root,0,0


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Update all 8 pythia6.428-1.0 DIS ep NC CSV files (10x130 and 10x250, all Q2 bins) to append `_run[0-9]+$` to the file path pattern, matching the 10 run files per Q2 bin present on disk and consistent with the BeAGLE CSV convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### What is the urgency of this PR?
- [ ] High
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
