### PR TITLE
Add pythia8.312-2.0 D0 and Lc ep configurations for 10x130 and 10x250

### DIFF
--- a/SIDIS/config.yml
+++ b/SIDIS/config.yml
@@ -69,6 +69,9 @@ SIDIS:ep:nevents:
         - "SIDIS/pythia8.306-1.0_Lambda_18x275_hiAcc.csv"
         - "SIDIS/pythia8.306-1.0_Lambda_18x275_hiDiv.csv"
         - "SIDIS/DIJET/pythia6.428-dijet-v1.0_PGF_noRC_ep_18x275_q2_1to20000_ab.csv"
+        - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x130_q2_1.csv"
+        - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x250_q2_1.csv"
+        - "SIDIS/ep/pythia8.312-2.0_Lc_ep_10x250_q2_1.csv"
 
 SIDIS:ep:timings:
   extends: .timings
@@ -91,6 +94,9 @@ SIDIS:ep:timings:
         - "SIDIS/pythia8.306-1.0_Lambda_18x275_hiAcc.csv"
         - "SIDIS/pythia8.306-1.0_Lambda_18x275_hiDiv.csv"
         - "SIDIS/DIJET/pythia6.428-dijet-v1.0_PGF_noRC_ep_18x275_q2_1to20000_ab.csv"
+        - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x130_q2_1.csv"
+        - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x250_q2_1.csv"
+        - "SIDIS/ep/pythia8.312-2.0_Lc_ep_10x250_q2_1.csv"
 
 SIDIS:collect:
   extends: .collect

--- a/SIDIS/ep/pythia8.312-2.0_D0_ep_10x130_q2_1.csv
+++ b/SIDIS/ep/pythia8.312-2.0_D0_ep_10x130_q2_1.csv
@@ -1,0 +1,1 @@
+SIDIS/D0_ABCONV/HFsim-PYTHIA/pythia8.312-2.0/ep/10x130/q2_1/pythia8.312-2.0_D0_ep_10x130_q2_1_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/SIDIS/ep/pythia8.312-2.0_D0_ep_10x250_q2_1.csv
+++ b/SIDIS/ep/pythia8.312-2.0_D0_ep_10x250_q2_1.csv
@@ -1,0 +1,1 @@
+SIDIS/D0_ABCONV/HFsim-PYTHIA/pythia8.312-2.0/ep/10x250/q2_1/pythia8.312-2.0_D0_ep_10x250_q2_1_ab_run[0-9]+$,hepmc3.tree.root,0,0

--- a/SIDIS/ep/pythia8.312-2.0_Lc_ep_10x250_q2_1.csv
+++ b/SIDIS/ep/pythia8.312-2.0_Lc_ep_10x250_q2_1.csv
@@ -1,0 +1,1 @@
+SIDIS/Lc_ABCONV/HFsim-PYTHIA/pythia8.312-2.0/ep/10x250/q2_1/pythia8.312-2.0_Lc_ep_10x250_q2_1_ab_run[0-9]+$,hepmc3.tree.root,0,0


### PR DESCRIPTION
Add pythia8.312-2.0 D0 and Lc ep configurations for 10x130 and 10x250 https://github.com/eic/HFsim-PYTHIA/releases/tag/Pythia8.312-2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


