### PR TITLE
Add pythia6-eic 1.2.0 ep_noradcor SIDIS configuration

### DIFF
--- a/SIDIS/config.yml
+++ b/SIDIS/config.yml
@@ -72,6 +72,20 @@ SIDIS:ep:nevents:
         - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x130_q2_1.csv"
         - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x250_q2_1.csv"
         - "SIDIS/ep/pythia8.312-2.0_Lc_ep_10x250_q2_1.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_0to1.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1to10.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_10to100.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_100to1000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1000to100000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_0to1.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1to10.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_10to100.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_100to1000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1000to100000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1to10.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_10to100.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_100to1000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1000to100000.csv"
 
 SIDIS:ep:timings:
   extends: .timings
@@ -97,6 +111,20 @@ SIDIS:ep:timings:
         - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x130_q2_1.csv"
         - "SIDIS/ep/pythia8.312-2.0_D0_ep_10x250_q2_1.csv"
         - "SIDIS/ep/pythia8.312-2.0_Lc_ep_10x250_q2_1.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_0to1.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1to10.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_10to100.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_100to1000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1000to100000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_0to1.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1to10.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_10to100.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_100to1000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1000to100000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1to10.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_10to100.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_100to1000.csv"
+        - "SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1000to100000.csv"
 
 SIDIS:collect:
   extends: .collect

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1000to100000.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1000to100000.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/10x100/q2_1000to100000/pythia6-eic_1.2.0_ep_noradcor_10x100_q2_1000_100000_run[0-9]+.ab$,hepmc3.tree.root,75000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_100to1000.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_100to1000.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/10x100/q2_100to1000/pythia6-eic_1.2.0_ep_noradcor_10x100_q2_100_1000_run[0-9]+.ab$,hepmc3.tree.root,75000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_10to100.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_10to100.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/10x100/q2_10to100/pythia6-eic_1.2.0_ep_noradcor_10x100_q2_10_100_run[0-9]+.ab$,hepmc3.tree.root,75000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1to10.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_10x100_q2_1to10.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/10x100/q2_1to10/pythia6-eic_1.2.0_ep_noradcor_10x100_q2_1_10_run[0-9]+.ab$,hepmc3.tree.root,75000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_0to1.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_0to1.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/18x275/q2_0to1/pythia6-eic_1.2.0_ep_noradcor_18x275_q2_0_1_run[0-9]+.ab$,hepmc3.tree.root,30000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1000to100000.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1000to100000.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/18x275/q2_1000to100000/pythia6-eic_1.2.0_ep_noradcor_18x275_q2_1000_100000_run[0-9]+.ab$,hepmc3.tree.root,15000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_100to1000.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_100to1000.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/18x275/q2_100to1000/pythia6-eic_1.2.0_ep_noradcor_18x275_q2_100_1000_run[0-9]+.ab$,hepmc3.tree.root,15000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_10to100.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_10to100.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/18x275/q2_10to100/pythia6-eic_1.2.0_ep_noradcor_18x275_q2_10_100_run[0-9]+.ab$,hepmc3.tree.root,37500,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1to10.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_18x275_q2_1to10.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/18x275/q2_1to10/pythia6-eic_1.2.0_ep_noradcor_18x275_q2_1_10_run[0-9]+.ab$,hepmc3.tree.root,50000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_0to1.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_0to1.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/5x41/q2_0to1/pythia6-eic_1.2.0_ep_noradcor_5x41_q2_0_1_run[0-9]+.ab$,hepmc3.tree.root,30000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1000to100000.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1000to100000.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/5x41/q2_1000to100000/pythia6-eic_1.2.0_ep_noradcor_5x41_q2_1000_100000_run[0-9]+.ab$,hepmc3.tree.root,15000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_100to1000.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_100to1000.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/5x41/q2_100to1000/pythia6-eic_1.2.0_ep_noradcor_5x41_q2_100_1000_run[0-9]+.ab$,hepmc3.tree.root,15000,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_10to100.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_10to100.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/5x41/q2_10to100/pythia6-eic_1.2.0_ep_noradcor_5x41_q2_10_100_run[0-9]+.ab$,hepmc3.tree.root,37500,0

--- a/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1to10.csv
+++ b/SIDIS/pythia6-eic/1.2.0/ep/noradcor/pythia6-eic-1.2.0_ep_noradcor_5x41_q2_1to10.csv
@@ -1,0 +1,1 @@
+SIDIS/pythia6-eic/1.2.0/ep_noradcor/5x41/q2_1to10/pythia6-eic_1.2.0_ep_noradcor_5x41_q2_1_10_run[0-9]+.ab$,hepmc3.tree.root,37500,0


### PR DESCRIPTION
Add 14 CSV metadata files for pythia6-eic/1.2.0 ep_noradcor across 3 beam energies (10x100, 18x275, 5x41) and 4-5 Q2 ranges each, with 1.5 million events per sample. Update SIDIS config.yml to include new datasets in both nevents and timings jobs.
https://gitlab.com/eic/mceg/PYTHIA-RAD-CORR/-/tags/1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
