### PR TITLE
Add UPSILON threshold HEPMC3 configurations

### DIFF
--- a/EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiAcc.csv
+++ b/EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiAcc.csv
@@ -1,0 +1,1 @@
+EXCLUSIVE/UPSILON_ABCONV/upsilon1s_threshold_ab_hiAcc_10x100,hepmc3.tree.root,0,0

--- a/EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiDiv.csv
+++ b/EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiDiv.csv
@@ -1,0 +1,1 @@
+EXCLUSIVE/UPSILON_ABCONV/upsilon1s_threshold_ab_hiDiv_10x100,hepmc3.tree.root,0,0

--- a/EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiAcc.csv
+++ b/EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiAcc.csv
@@ -1,0 +1,1 @@
+EXCLUSIVE/UPSILON_ABCONV/upsilon1s_threshold_ab_hiAcc_18x275,hepmc3.tree.root,0,0

--- a/EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiDiv.csv
+++ b/EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiDiv.csv
@@ -1,0 +1,1 @@
+EXCLUSIVE/UPSILON_ABCONV/upsilon1s_threshold_ab_hiDiv_18x275,hepmc3.tree.root,0,0

--- a/EXCLUSIVE/UPSILON/config.yml
+++ b/EXCLUSIVE/UPSILON/config.yml
@@ -5,6 +5,10 @@ EXCLUSIVE:UPSILON:nevents:
       - DATA:
         - "EXCLUSIVE/UPSILON/UPSILON_18x275_hiAcc.csv"
         - "EXCLUSIVE/UPSILON/UPSILON_18x275_hiDiv.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiAcc.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiDiv.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiAcc.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiDiv.csv"
 
 EXCLUSIVE:UPSILON:timings:
   extends: .timings
@@ -15,6 +19,10 @@ EXCLUSIVE:UPSILON:timings:
       - DATA:
         - "EXCLUSIVE/UPSILON/UPSILON_18x275_hiAcc.csv"
         - "EXCLUSIVE/UPSILON/UPSILON_18x275_hiDiv.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiAcc.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_10x100_hiDiv.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiAcc.csv"
+        - "EXCLUSIVE/UPSILON/UPSILON_threshold_18x275_hiDiv.csv"
 
 EXCLUSIVE:UPSILON:collect:
   extends: .collect


### PR DESCRIPTION
Add CSV files for UPSILON threshold hepmc3.tree.root datasets at 10x100 and 18x275 beam energies with hiAcc/hiDiv variants.

Files added:
- UPSILON_threshold_10x100_hiAcc.csv
- UPSILON_threshold_10x100_hiDiv.csv
- UPSILON_threshold_18x275_hiAcc.csv
- UPSILON_threshold_18x275_hiDiv.csv

Updated EXCLUSIVE/UPSILON/config.yml to include new datasets in nevents and timings jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
