### PR TITLE
Add EW_BSM physics category with ALP datasets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,7 @@ include:
   - local: 'BACKGROUNDS/config.yml'
   - local: 'DDIS/config.yml'
   - local: 'DIS/config.yml'
+  - local: 'EW_BSM/config.yml'
   - local: 'EXCLUSIVE/config.yml'
   - local: 'SIDIS/config.yml'
   - local: 'SINGLE/config.yml'
@@ -116,6 +117,7 @@ collect:
     - "BACKGROUNDS:collect"
     - "DDIS:collect"
     - "DIS:collect"
+    - "EW_BSM:collect"
     - "EXCLUSIVE:collect"
     - "SIDIS:collect"
     - "SINGLE:collect"

--- a/EW_BSM/ALP/10x110/config.yml
+++ b/EW_BSM/ALP/10x110/config.yml
@@ -1,4 +1,10 @@
+.EW_BSM_ALP_10x110_variables: &EW_BSM_ALP_10x110_variables
+  EBEAM_OVERRIDE: "10"
+  PBEAM_OVERRIDE: "110_Pb208"
+
 EW_BSM:ALP:10x110:nevents:
+  variables:
+    <<: *EW_BSM_ALP_10x110_variables
   extends: .nevents
   parallel:
     matrix:
@@ -21,6 +27,8 @@ EW_BSM:ALP:10x110:nevents:
         - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0.csv"
 
 EW_BSM:ALP:10x110:timings:
+  variables:
+    <<: *EW_BSM_ALP_10x110_variables
   extends: .timings
   needs:
     - EW_BSM:ALP:10x110:nevents
@@ -45,6 +53,8 @@ EW_BSM:ALP:10x110:timings:
         - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0.csv"
 
 EW_BSM:ALP:10x110:collect:
+  variables:
+    <<: *EW_BSM_ALP_10x110_variables
   extends: .collect
   needs:
     - EW_BSM:ALP:10x110:timings

--- a/EW_BSM/ALP/10x110/config.yml
+++ b/EW_BSM/ALP/10x110/config.yml
@@ -1,0 +1,50 @@
+EW_BSM:ALP:10x110:nevents:
+  extends: .nevents
+  parallel:
+    matrix:
+      - DATA:
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.1.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.2.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.5.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_1.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_2.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_5.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_10.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_20.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.1.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.2.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.5.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_1.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_2.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_5.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_10.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0.csv"
+
+EW_BSM:ALP:10x110:timings:
+  extends: .timings
+  needs:
+    - EW_BSM:ALP:10x110:nevents
+  parallel:
+    matrix:
+      - DATA:
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.1.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.2.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.5.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_1.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_2.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_5.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_10.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_20.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.1.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.2.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.5.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_1.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_2.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_5.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_10.0.csv"
+        - "EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0.csv"
+
+EW_BSM:ALP:10x110:collect:
+  extends: .collect
+  needs:
+    - EW_BSM:ALP:10x110:timings

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.1.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.1.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_0.1/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.1_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.2.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.2.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_0.2/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.2_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.5.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.5.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_0.5/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_0.5_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_1.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_1.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_1.0/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_1.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_10.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_10.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_10.0/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_10.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_2.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_2.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_2.0/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_2.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_20.0/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_20.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_5.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_5.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-ax-emmupmum/10x110/ma_5.0/madgraph5-3.7.0-1.0_aem-ax-emmupmum_10x110_ma_5.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.1.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.1.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_0.1/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.1_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.2.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.2.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_0.2/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.2_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.5.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.5.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_0.5/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_0.5_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_1.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_1.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_1.0/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_1.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_10.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_10.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_10.0/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_10.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_2.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_2.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_2.0/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_2.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_20.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_20.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_20.0/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_20.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_5.0.csv
+++ b/EW_BSM/ALP/10x110/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_5.0.csv
@@ -1,0 +1,1 @@
+EW_BSM/ALP/madgraph5-3.7.0-1.0/aem-axem/10x110/ma_5.0/madgraph5-3.7.0-1.0_aem-axem_10x110_ma_5.0_run[0-9]+,hepmc3.tree.root,0,0

--- a/EW_BSM/ALP/config.yml
+++ b/EW_BSM/ALP/config.yml
@@ -1,0 +1,7 @@
+include:
+  - local: 'EW_BSM/ALP/10x110/config.yml'
+
+EW_BSM:ALP:collect:
+  extends: .collect
+  needs:
+    - EW_BSM:ALP:10x110:collect

--- a/EW_BSM/config.yml
+++ b/EW_BSM/config.yml
@@ -1,0 +1,7 @@
+include:
+  - local: 'EW_BSM/ALP/config.yml'
+
+EW_BSM:collect:
+  extends: .collect
+  needs:
+    - EW_BSM:ALP:collect


### PR DESCRIPTION
Added new physics category EW_BSM (Electroweak Beyond Standard Model) for Axion-Like Particle (ALP) production datasets.

Structure:
- EW_BSM/ALP/10x110/ with 16 CSV configurations
- 2 processes: aem-axem and aem-ax-emmupmum
- 8 mass points each: ma = 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0 GeV
- Hierarchical config.yml files following existing EXCLUSIVE pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
